### PR TITLE
Easily run tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+services:
+ - docker
+script:
+ - ./test.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM hashicorp/terraform:0.11.4
+
+WORKDIR /opt/
+
+ENV AWS_DEFAULT_REGION eu-west-1 
+ENV PYTHONPATH /opt/scripts/
+
+RUN apk add --no-cache python3 && \
+    pip3 install boto3
+
+COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,6 @@ ENV AWS_DEFAULT_REGION eu-west-1
 ENV PYTHONPATH /opt/scripts/
 
 RUN apk add --no-cache python3 && \
-    pip3 install boto3
+    pip3 install boto3 flake8
 
 COPY . .

--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-# tf_centralised_aws_backup_selection
+# tf_centralised_aws_backup_selection [![Build Status](https://travis-ci.org/mergermarket/tf_centralised_aws_backup_selection.svg?branch=master)](https://travis-ci.org/mergermarket/tf_centralised_aws_backup_selection)

--- a/scripts/get_plan_id.py
+++ b/scripts/get_plan_id.py
@@ -1,6 +1,8 @@
-import boto3
 import json
 import sys
+
+import boto3
+
 
 def read_in(input):
     lines = {x.strip() for x in input}
@@ -9,6 +11,7 @@ def read_in(input):
         if line:
             jsondata = json.loads(line)
     return jsondata
+
 
 def main(input, output, client):
     jsondata = read_in(input)
@@ -20,7 +23,12 @@ def main(input, output, client):
 
     for backupPlan in response['BackupPlansList']:
         if jsondata['plan_name'] == backupPlan['BackupPlanName']:
-            output.write(json.dumps({"plan_id":backupPlan['BackupPlanId']}))
+            output.write(json.dumps({"plan_id": backupPlan['BackupPlanId']}))
+
 
 if __name__ == '__main__':
-    main(sys.stdin, sys.stdout, boto3.client('backup', region_name='eu-west-1'))
+    main(
+        sys.stdin,
+        sys.stdout,
+        boto3.client('backup', region_name='eu-west-1'),
+    )

--- a/scripts/test_get_plan_id.py
+++ b/scripts/test_get_plan_id.py
@@ -1,9 +1,11 @@
-import sys, io
+import io
 import unittest
+
 import get_plan_id
 
+
 class MockClient:
-    def list_backup_plans(client, **meh):
+    def list_backup_plans(client, **args):
         return {
             'NextToken': 'string',
             'BackupPlansList': [
@@ -14,16 +16,20 @@ class MockClient:
             ]
         }
 
+
 class TestGetPlanId(unittest.TestCase):
 
     def test_read_in(self):
         input = io.StringIO('{"test":"12345"}')
         result = get_plan_id.read_in(input)
-        self.assertEqual(result, {"test":"12345"})
+        self.assertEqual(result, {"test": "12345"})
 
     def test_main(self):
         input = io.StringIO('{"plan_name":"daily_expire_28_days"}')
         output = io.StringIO()
         get_plan_id.main(input, output, MockClient())
         output.seek(0)
-        self.assertEqual(output.read(), '{"plan_id": "93640b53-1be7-4c16-81d2-987c2f218ddd"}')
+        self.assertEqual(
+            output.read(),
+            '{"plan_id": "93640b53-1be7-4c16-81d2-987c2f218ddd"}',
+        )

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -euo pipefail
+
+IMAGE_ID="$(basename $(pwd))"
+
+function cleanup() {
+    docker container rm --force "${IMAGE_ID}"
+}
+
+function run_in_container() {
+    docker container exec -i \
+        "$(tty -s && echo -t)" \
+        "${IMAGE_ID}" \
+        "${@}"
+}
+
+trap cleanup EXIT
+
+docker image build -t "${IMAGE_ID}" .
+
+docker container run \
+    --name "${IMAGE_ID}" \
+    --entrypoint= \
+    -d \
+    "${IMAGE_ID}" \
+    tail -f /dev/null
+
+run_in_container terraform init
+run_in_container terraform validate -var plan_name=myplan -var database=mydb
+run_in_container python3 -m unittest discover scripts

--- a/test.sh
+++ b/test.sh
@@ -29,3 +29,4 @@ docker container run \
 run_in_container terraform init
 run_in_container terraform validate -var plan_name=myplan -var database=mydb
 run_in_container python3 -m unittest discover scripts
+run_in_container flake8 scripts


### PR DESCRIPTION
Add a Dockerfile and test script to run tests - there are some lovely tests for the Python script so this adds a way for everyone to run them easily. The test for the Terraform code is simply that it passes validation.

Add linting via flake8 to the Python script - this is handy for enforcing style but also for finding unused imports and other potential sources of bugs.

Add a config file for Travis CI and a status badge to readme. Make sure that tests are run on changes to the repo and display the status of the tests on CI for all to see.